### PR TITLE
プロフィール更新APIの作成

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -2,4 +2,18 @@ class Api::V1::ProfilesController < ApplicationController
   def show
     render json: current_user, status: :ok
   end
+
+  def update
+    if current_user.update(profile_params)
+      render json: current_user, serializer: ProfileSerializer, status: :created
+    else
+      render json: { errors: current_user.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:avatar, :name)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 15 }
+
   def self.find_or_create_user(user_info)
     uid = user_info[:uid]
     user = User.find_by(uid:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       post '/auth', to: 'authentications#create'
       resources :morays, only: %i[index]
       resources :aquaria, only: %i[index]
-      resource :profile, only: %i[show]
+      resource :profile, only: %i[show update]
     end
   end
 end


### PR DESCRIPTION
## 対象Issue

[プロフィール更新APIの作成 #21](https://github.com/Utsubo256/utsubo-site-api/issues/21)

## 実施内容

- ProfilesControllerのupdateアクションを実装

## 動作確認

1. terminal上で以下のcurlコマンドを実行

```
curl -X PATCH -H "Content-Type: application/json" -H "authorization: Bearer (token)" -d '{"profile":{"avatar":null, "name":"Utsubo"}}' localhost:3000/api/v1/profile
```

2. 更新したプロフィール情報が返ってくることを確認

```
{"name":"Utsubo","avatar":null}
```

3. railsコンソールにて対象ユーザープロフィールのDBの値も更新されていることを確認

```
User.first
=>
...
  name: "Utsubo",                                               
  avatar: nil,                                                  
  created_at: Tue, 18 Apr 2023 03:56:50.257568000 UTC +00:00,   
  updated_at: Sat, 29 Apr 2023 04:42:20.351318000 UTC +00:00>]  
```

close #21 