### PR TITLE
オートスリープしないよう設定変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,8 @@ primary_region = "nrt"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = true
-  auto_start_machines = true
+  auto_stop_machines = false
+  auto_start_machines = false
 
 [[statics]]
   guest_path = "/rails/public"


### PR DESCRIPTION
## 対象Issue

[fly.ioの設定変更 #34](https://github.com/Utsubo256/utsubo-site-api/issues/34)

## 実施内容

- オートスリープしないように、fly.tomlの設定を変更

## 動作確認

- 本番環境でオートスリープしないことを確認

close #34 